### PR TITLE
docs: add comprehensive commit message guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,44 @@ make test-perf
    # Binary will be in _output/bin/
    ```
 
+### Commit Message Guidelines
+
+When working in forks and contributing back to the main repository, follow these commit message conventions:
+
+1. **Issue References:**
+   - **Always use** `vmware-tanzu/velero#123` format when referencing issues
+   - **Never use** `kaovilai/velero#123` or bare `#123` references
+   - This ensures commit messages point to the canonical upstream repository
+
+2. **Single Commit Per Branch:**
+   - Maintain only **1 commit** between `vmware-tanzu/velero:main` and your feature branch
+   - Use `git commit --amend` or `git rebase -i` to squash multiple commits
+   - Exception: When targeting release branches, follow the same single-commit rule relative to that base branch
+
+3. **Commit Message Format:**
+   ```bash
+   # Good examples:
+   git commit -m "fix: resolve backup timeout issue
+
+   Fixes vmware-tanzu/velero#123"
+
+   git commit -m "feat: add support for custom retention policies
+
+   Implements vmware-tanzu/velero#456"
+
+   # Bad examples (avoid these):
+   git commit -m "fix issue #123"           # Missing repo reference
+   git commit -m "fix kaovilai/velero#123"  # Wrong repo reference
+   ```
+
+4. **Squashing Commits:**
+   ```bash
+   # If you have multiple commits, squash them:
+   git rebase -i HEAD~3  # Interactive rebase for last 3 commits
+   # Or amend your latest commit:
+   git commit --amend -m "Updated commit message"
+   ```
+
 ### Code Quality
 
 The project uses:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ When working in forks and contributing back to the main repository, follow these
 1. **Issue References:**
    - **Always use** `vmware-tanzu/velero#123` format when referencing issues
    - **Never use** `kaovilai/velero#123` or bare `#123` references
+   - **Exception:** Bare `#123` references are allowed for changes targeting `kaovilai/main` (such as CLAUDE.md updates)
    - This ensures commit messages point to the canonical upstream repository
 
 2. **Single Commit Per Branch:**
@@ -192,8 +193,13 @@ When working in forks and contributing back to the main repository, follow these
 
    Implements vmware-tanzu/velero#456"
 
+   # Good examples for kaovilai/main changes:
+   git commit -m "docs: add comprehensive commit message guidelines
+
+   Fixes #108"
+
    # Bad examples (avoid these):
-   git commit -m "fix issue #123"           # Missing repo reference
+   git commit -m "fix issue #123"           # Missing repo reference (unless for kaovilai/main)
    git commit -m "fix kaovilai/velero#123"  # Wrong repo reference
    ```
 


### PR DESCRIPTION
Add guidance for proper issue references and single-commit branches:
- Always use vmware-tanzu/velero#123 format for issue references
- Maintain only 1 commit between base branch and feature branch
- Include practical examples and squashing strategies

Fixes #108

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed commit message guidelines to the development workflow documentation, including conventions for referencing issues, maintaining a single commit per branch, and instructions for squashing commits. Examples of correct and incorrect commit message formats are provided to help standardize contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->