### PR TITLE
feat: add CRD schema validation during server startup

### DIFF
--- a/pkg/cmd/server/config/config.go
+++ b/pkg/cmd/server/config/config.go
@@ -181,6 +181,7 @@ type Config struct {
 	RepoMaintenanceJobConfig       string
 	ItemBlockWorkerCount           int
 	ConcurrentBackups              int
+	CRDSchemaCheck                 string
 }
 
 func GetDefaultConfig() *Config {
@@ -214,6 +215,7 @@ func GetDefaultConfig() *Config {
 		CredentialsDirectory:           credentials.DefaultStoreDirectory(),
 		ItemBlockWorkerCount:           DefaultItemBlockWorkerCount,
 		ConcurrentBackups:              DefaultConcurrentBackups,
+		CRDSchemaCheck:                 "warn",
 	}
 
 	return config
@@ -274,5 +276,11 @@ func (c *Config) BindFlags(flags *pflag.FlagSet) {
 		"concurrent-backups",
 		c.ConcurrentBackups,
 		"Number of backups to process concurrently. Default is one. Optional.",
+	)
+	flags.StringVar(
+		&c.CRDSchemaCheck,
+		"crd-schema-check",
+		c.CRDSchemaCheck,
+		"CRD schema validation mode during server startup. Valid values: warn (default, log error but start), strict (fail to start), skip (no check).",
 	)
 }

--- a/pkg/cmd/server/crd_check.go
+++ b/pkg/cmd/server/crd_check.go
@@ -1,0 +1,231 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	velerov2alpha1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
+)
+
+type crdSchemaExpectation struct {
+	crdName            string
+	specType           reflect.Type
+	statusType         reflect.Type
+	apiGroupVersion    string
+	storedVersionLabel string
+}
+
+func expectedCRDSchemas() []crdSchemaExpectation {
+	var expectations []crdSchemaExpectation
+
+	for kind, info := range velerov1api.CustomResources() {
+		exp := crdSchemaExpectation{
+			crdName:            info.PluralName + "." + velerov1api.SchemeGroupVersion.Group,
+			apiGroupVersion:    velerov1api.SchemeGroupVersion.Version,
+			storedVersionLabel: kind,
+		}
+		itemType := reflect.TypeOf(info.ItemType)
+		if itemType.Kind() == reflect.Pointer {
+			itemType = itemType.Elem()
+		}
+		if specField, ok := itemType.FieldByName("Spec"); ok {
+			exp.specType = specField.Type
+		}
+		if statusField, ok := itemType.FieldByName("Status"); ok {
+			exp.statusType = statusField.Type
+		}
+		expectations = append(expectations, exp)
+	}
+
+	for kind, info := range velerov2alpha1api.CustomResources() {
+		exp := crdSchemaExpectation{
+			crdName:            info.PluralName + "." + velerov2alpha1api.SchemeGroupVersion.Group,
+			apiGroupVersion:    velerov2alpha1api.SchemeGroupVersion.Version,
+			storedVersionLabel: kind,
+		}
+		itemType := reflect.TypeOf(info.ItemType)
+		if itemType.Kind() == reflect.Pointer {
+			itemType = itemType.Elem()
+		}
+		if specField, ok := itemType.FieldByName("Spec"); ok {
+			exp.specType = specField.Type
+		}
+		if statusField, ok := itemType.FieldByName("Status"); ok {
+			exp.statusType = statusField.Type
+		}
+		expectations = append(expectations, exp)
+	}
+
+	return expectations
+}
+
+// jsonFieldNames extracts top-level JSON field names from a Go struct type using reflection.
+func jsonFieldNames(t reflect.Type) sets.Set[string] {
+	if t == nil {
+		return nil
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	fields := sets.New[string]()
+	for field := range t.Fields() {
+		if field.Anonymous {
+			embedded := jsonFieldNames(field.Type)
+			fields = fields.Union(embedded)
+			continue
+		}
+		tag := field.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			continue
+		}
+		fields.Insert(name)
+	}
+	return fields
+}
+
+// schemaPropertyNames extracts top-level property names from a CRD OpenAPI schema.
+func schemaPropertyNames(schema *apiextv1.JSONSchemaProps, path string) sets.Set[string] {
+	if schema == nil {
+		return nil
+	}
+
+	current := schema
+	for segment := range strings.SplitSeq(path, ".") {
+		if segment == "" {
+			continue
+		}
+		if current.Properties == nil {
+			return nil
+		}
+		next, ok := current.Properties[segment]
+		if !ok {
+			return nil
+		}
+		current = &next
+	}
+
+	if current.Properties == nil {
+		return nil
+	}
+
+	names := sets.New[string]()
+	for name := range current.Properties {
+		names.Insert(name)
+	}
+	return names
+}
+
+func (s *server) validateCRDSchemas() error {
+	mode := s.config.CRDSchemaCheck
+	if mode == "skip" {
+		s.logger.Info("CRD schema validation skipped (--crd-schema-check=skip)")
+		return nil
+	}
+
+	s.logger.Info("Validating CRD schemas match server expectations")
+
+	apiextClient, err := apiextclient.NewForConfig(s.kubeClientConfig)
+	if err != nil {
+		return errors.Wrap(err, "creating apiextensions client for CRD schema validation")
+	}
+
+	expectations := expectedCRDSchemas()
+	var allMissing []string
+
+	for _, exp := range expectations {
+		crd, err := apiextClient.ApiextensionsV1().CustomResourceDefinitions().Get(
+			context.TODO(), exp.crdName, metav1.GetOptions{})
+		if err != nil {
+			s.logger.WithField("crd", exp.crdName).WithError(err).Warn("Could not fetch CRD for schema validation")
+			continue
+		}
+
+		var versionSchema *apiextv1.CustomResourceValidation
+		for _, v := range crd.Spec.Versions {
+			if v.Name == exp.apiGroupVersion {
+				versionSchema = v.Schema
+				break
+			}
+		}
+		if versionSchema == nil || versionSchema.OpenAPIV3Schema == nil {
+			s.logger.WithField("crd", exp.crdName).Warn("CRD has no OpenAPI schema for version " + exp.apiGroupVersion)
+			continue
+		}
+
+		schema := versionSchema.OpenAPIV3Schema
+
+		missing := checkMissing(exp.specType, schema, "spec", exp.crdName)
+		missing = append(missing, checkMissing(exp.statusType, schema, "status", exp.crdName)...)
+
+		allMissing = append(allMissing, missing...)
+	}
+
+	if len(allMissing) > 0 {
+		msg := fmt.Sprintf("CRD schema mismatch detected — %d field(s) expected by server not found in installed CRDs. "+
+			"Update CRDs with: velero install --crds-only\n", len(allMissing))
+		for _, m := range allMissing {
+			msg += "  - " + m + "\n"
+		}
+
+		if mode == "strict" {
+			return errors.New(msg)
+		}
+		s.logger.Error(msg)
+	} else {
+		s.logger.Info("All CRD schemas match server expectations")
+	}
+
+	return nil
+}
+
+func checkMissing(goType reflect.Type, schema *apiextv1.JSONSchemaProps, section, crdName string) []string {
+	if goType == nil {
+		return nil
+	}
+	expectedFields := jsonFieldNames(goType)
+	installedFields := schemaPropertyNames(schema, section)
+	if installedFields == nil {
+		return nil
+	}
+
+	var missing []string
+	for field := range expectedFields {
+		if !installedFields.Has(field) {
+			missing = append(missing, fmt.Sprintf("%s: %s.%s", crdName, section, field))
+		}
+	}
+	return missing
+}

--- a/pkg/cmd/server/crd_check_test.go
+++ b/pkg/cmd/server/crd_check_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright The Velero Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type TestBase struct {
+	Name  string `json:"name"`
+	Count int    `json:"count,omitempty"`
+}
+
+type testSpec struct {
+	Name    string `json:"name"`
+	Count   int    `json:"count,omitempty"`
+	Ignored string `json:"-"`
+	private string //nolint:unused
+}
+
+type testSpecWithEmbedded struct {
+	TestBase
+	Extra string `json:"extra"`
+}
+
+func TestJsonFieldNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    reflect.Type
+		expected []string
+	}{
+		{
+			name:     "simple struct",
+			input:    reflect.TypeFor[testSpec](),
+			expected: []string{"name", "count"},
+		},
+		{
+			name:     "pointer to struct",
+			input:    reflect.TypeFor[*testSpec](),
+			expected: []string{"name", "count"},
+		},
+		{
+			name:     "struct with anonymous embedded",
+			input:    reflect.TypeFor[testSpecWithEmbedded](),
+			expected: []string{"name", "count", "extra"},
+		},
+		{
+			name:     "nil type",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := jsonFieldNames(tc.input)
+			if tc.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+			for _, field := range tc.expected {
+				assert.True(t, result.Has(field), "expected field %q", field)
+			}
+			assert.False(t, result.Has("Ignored"))
+			assert.False(t, result.Has("private"))
+		})
+	}
+}
+
+func TestSchemaPropertyNames(t *testing.T) {
+	schema := &apiextv1.JSONSchemaProps{
+		Properties: map[string]apiextv1.JSONSchemaProps{
+			"spec": {
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"name":  {Type: "string"},
+					"count": {Type: "integer"},
+				},
+			},
+			"status": {
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"phase":   {Type: "string"},
+					"message": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	t.Run("extract spec properties", func(t *testing.T) {
+		result := schemaPropertyNames(schema, "spec")
+		require.NotNil(t, result)
+		assert.True(t, result.Has("name"))
+		assert.True(t, result.Has("count"))
+		assert.Equal(t, 2, result.Len())
+	})
+
+	t.Run("extract status properties", func(t *testing.T) {
+		result := schemaPropertyNames(schema, "status")
+		require.NotNil(t, result)
+		assert.True(t, result.Has("phase"))
+		assert.True(t, result.Has("message"))
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		result := schemaPropertyNames(schema, "nonexistent")
+		assert.Nil(t, result)
+	})
+
+	t.Run("nil schema", func(t *testing.T) {
+		result := schemaPropertyNames(nil, "spec")
+		assert.Nil(t, result)
+	})
+}
+
+func TestCheckMissing(t *testing.T) {
+	schema := &apiextv1.JSONSchemaProps{
+		Properties: map[string]apiextv1.JSONSchemaProps{
+			"spec": {
+				Properties: map[string]apiextv1.JSONSchemaProps{
+					"name": {Type: "string"},
+				},
+			},
+		},
+	}
+
+	t.Run("missing field detected", func(t *testing.T) {
+		missing := checkMissing(reflect.TypeFor[testSpec](), schema, "spec", "tests.velero.io")
+		assert.Len(t, missing, 1)
+		assert.Contains(t, missing[0], "count")
+	})
+
+	t.Run("no missing fields", func(t *testing.T) {
+		fullSchema := &apiextv1.JSONSchemaProps{
+			Properties: map[string]apiextv1.JSONSchemaProps{
+				"spec": {
+					Properties: map[string]apiextv1.JSONSchemaProps{
+						"name":  {Type: "string"},
+						"count": {Type: "integer"},
+					},
+				},
+			},
+		}
+		missing := checkMissing(reflect.TypeFor[testSpec](), fullSchema, "spec", "tests.velero.io")
+		assert.Empty(t, missing)
+	})
+
+	t.Run("extra fields in CRD are OK", func(t *testing.T) {
+		extraSchema := &apiextv1.JSONSchemaProps{
+			Properties: map[string]apiextv1.JSONSchemaProps{
+				"spec": {
+					Properties: map[string]apiextv1.JSONSchemaProps{
+						"name":      {Type: "string"},
+						"count":     {Type: "integer"},
+						"newField":  {Type: "string"},
+						"anotherEx": {Type: "boolean"},
+					},
+				},
+			},
+		}
+		missing := checkMissing(reflect.TypeFor[testSpec](), extraSchema, "spec", "tests.velero.io")
+		assert.Empty(t, missing)
+	})
+
+	t.Run("nil go type", func(t *testing.T) {
+		missing := checkMissing(nil, schema, "spec", "tests.velero.io")
+		assert.Nil(t, missing)
+	})
+}
+
+func TestExpectedCRDSchemas(t *testing.T) {
+	expectations := expectedCRDSchemas()
+	assert.NotEmpty(t, expectations)
+
+	crdNames := make(map[string]bool)
+	for _, exp := range expectations {
+		crdNames[exp.crdName] = true
+		assert.NotEmpty(t, exp.crdName, "CRD name should not be empty")
+		assert.NotEmpty(t, exp.apiGroupVersion, "API group version should not be empty")
+	}
+
+	assert.True(t, crdNames["backups.velero.io"], "should include backups CRD")
+	assert.True(t, crdNames["restores.velero.io"], "should include restores CRD")
+	assert.True(t, crdNames["schedules.velero.io"], "should include schedules CRD")
+	assert.True(t, crdNames["datauploads.velero.io"], "should include datauploads CRD")
+	assert.True(t, crdNames["datadownloads.velero.io"], "should include datadownloads CRD")
+}

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -360,6 +360,10 @@ func (s *server) run() error {
 		return err
 	}
 
+	if err := s.validateCRDSchemas(); err != nil {
+		return err
+	}
+
 	s.checkNodeAgent()
 
 	if err := s.initRepoManager(); err != nil {


### PR DESCRIPTION
## Summary

- Add CRD schema validation during server startup that checks installed CRD schemas contain all fields the server expects
- Uses reflection on Go API types to derive expected JSON field names, then compares against OpenAPI v3 schema properties in installed CRDs
- Configurable via `--crd-schema-check` flag: `warn` (default), `strict`, `skip`

Addresses velero-io/velero#9260

## Design

**Approach**: Schema property validation (from [issue discussion](https://github.com/velero-io/velero/issues/9260#issuecomment-3286953150))

- Reflects on Go API types (`BackupSpec`, `RestoreSpec`, etc.) at runtime to get expected JSON field names
- Fetches installed CRDs via apiextensions client and extracts OpenAPI v3 schema properties
- Reports missing fields (server expects a field the CRD doesn't have = outdated CRD)
- Extra fields in CRD are OK (forward-compatible)
- No additional RBAC needed — Velero already has CRD Get permissions

**Key decisions**:
- Schema-based over version-label-based (per sseago's feedback — CRD changes can happen without controller-gen upgrades)
- Default to `warn` for backward compatibility
- Suggests `velero install --crds-only` in error message (#9132 already merged)

## Files changed

| File | Change |
|------|--------|
| `pkg/cmd/server/crd_check.go` | New — expected schema extraction + validation logic |
| `pkg/cmd/server/crd_check_test.go` | New — unit tests |
| `pkg/cmd/server/server.go` | Call `validateCRDSchemas()` after `veleroResourcesExist()` |
| `pkg/cmd/server/config/config.go` | Add `CRDSchemaCheck` field + `--crd-schema-check` flag |

## Test plan

- [x] Unit tests pass for `jsonFieldNames`, `schemaPropertyNames`, `checkMissing`, `expectedCRDSchemas`
- [ ] E2E: deploy with mismatched CRDs and verify warning logged
- [ ] E2E: deploy with `--crd-schema-check=strict` and mismatched CRDs, verify server fails to start
- [ ] E2E: deploy with `--crd-schema-check=skip` and verify no validation runs

> [!Note]
> Responses generated with Claude